### PR TITLE
Comment out Galaxy Training Academy tile

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,11 +235,11 @@ frontpage: true
                 </div>
             </div>
         </div>
-        <div class="card rounded border-0  mb-4 shadow-sm shadow-hover">
+        <!-- <div class="card rounded border-0  mb-4 shadow-sm shadow-hover">
             <a href="https://galaxyproject.org/news/2024-08-26-gta-registration/" class="stretched-link">
                 <img class="card-img" alt="GTA event image" src="{{'images/gta_2024_event.png' | relative_url}}">
             </a>
-        </div>
+        </div> -->
         {% include news-list.html amount=5 %}
         <div class="card rounded border-0 mb-4 shadow-sm">
             <div class="card-body">


### PR DESCRIPTION
Tested locally; the gta tile is gone and other tiles nicely rearranged themselves back to normal. 