### PR TITLE
remove GBCC banner tile

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@ frontpage: true
 </div> -->
 
  <div class="row">
-    <div class="col-12 col-md-6 mb-4">
+    <!-- <div class="col-12 col-md-6 mb-4">
         <div class="card rounded border-0 shadow-sm h-100 shadow-hover">
             <div class="card-body px-4 d-grid d-md-flex justify-content-center gap-4">
                 <a href="https://galaxyproject.org/events/2025-06-23-gbc-c2025/" class="stretched-link d-flex align-items-center justify-content-center">
@@ -100,8 +100,8 @@ frontpage: true
                 </div> 
             </div>
         </div>
-    </div>
-    <div class="col-12 col-md-6 mb-4">
+    </div> -->
+    <div class="col-12 mb-4">
         <div class="card rounded border-0 shadow-sm h-100 shadow-hover">
             <div class="card-body px-4 d-grid d-md-flex justify-content-center gap-4">
                 <a href="https://galaxyproject.org/events/2025-10-01-egd2025/" class="stretched-link d-flex align-items-center">


### PR DESCRIPTION
Closes #58.

Tile looks rather big now. This only concerns me slightly.

<img width="1397" height="528" alt="image" src="https://github.com/user-attachments/assets/5ba41b9d-4a44-47dc-b086-8191c191b784" />
