### PR TITLE
Add new customized TIaaS page

### DIFF
--- a/_data/topnav.yml
+++ b/_data/topnav.yml
@@ -26,7 +26,7 @@ subitems:
       # icon: screwdriver-wrench
       # icon_type: solid
     - title: Training Infrastructure as a Service
-      url: /request-tiaas
+      url: /tiaas-info
       # icon: graduation-cap
       # icon_type: solid
     - hr: true

--- a/index.html
+++ b/index.html
@@ -133,12 +133,12 @@ frontpage: true
                             Don't let a job queue ruin your workshop!
                         </p>
                         <div class="d-grid gap-3 d-sm-flex">
-                            <a class="btn btn-sm btn-galaxy px-3" type="button" href="https://usegalaxy-eu.github.io/tiaas.html">
-                                Learn more<i class="fa-solid fa-arrow-up-right-from-square ms-2 fa-sm"></i>
+                            <a class="btn btn-sm btn-galaxy px-3" type="button" href="{{'tiaas-info' | relative_url }}">
+                                Learn more
                             </a>
 
-                            <a class="btn btn-sm btn-galaxy px-3" type="button" href="{{'/request-tiaas' | relative_url }}">
-                                Enquire now
+                            <a class="btn btn-sm btn-galaxy px-3" type="button" href="https://usegalaxy.be/tiaas/">
+                                Enquire now<i class="fa-solid fa-arrow-up-right-from-square ms-2 fa-sm"></i>
                             </a>
                         </div>
                     </div>

--- a/tiaas-info.md
+++ b/tiaas-info.md
@@ -10,11 +10,11 @@ You provide the training, we provide the <strong>infrastructure at no cost</stro
 
 <ul>
   <!-- <li>Separate queue where only your training’s jobs will run.</li> -->
-  <li>No Galaxy maintenance.</li>
-  <li>No Galaxy administration.</li>
-  <li>Free infrastructure.</li>
+  <li>No Galaxy maintenance</li>
+  <li>No Galaxy administration</li>
+  <li>Free infrastructure</li>
   <li>Make use of <a href="https://training.galaxyproject.org">Galaxy Training Materials</a>.</li>
-  <li>See how your students are progressing on a dashboard.</li>
+  <li>See how your students are progressing on a dashboard</li>
 </ul>
 
 <h2 id="how-tiaas-works">How TIaaS Works</h2>
@@ -55,7 +55,7 @@ your workshop, then some of the <a href="https://usegalaxy.be/libraries/folders/
 <p>To keep running this free service for your trainees, <strong>we need your feedback and support</strong>. It would be great if you could:</p>
 
 <ul>
-  <li>Write a (short) testimonial about your experience with the provided TIaaS.</li>
+  <li>Write us a (short) testimonial about your experience with the provided TIaaS for us to use in our promotional materials, reports, and funding applications.</li>
   <li>If you made use of GTN material, fill in the feedback form found at the end of every GTN tutorial.</li>
   </ul>
 
@@ -63,7 +63,7 @@ your workshop, then some of the <a href="https://usegalaxy.be/libraries/folders/
 
 <p>We <em>cannot</em> promise any degree of uptime. We will do our best to have this service online and functioning during the entire time period, but there are cases where the service may experience interruptions that are outside of our control.</p>
 
-<h2 id="eligibility">Eligibility</h2>
+<h2 id="Availability">Availability</h2>
 
 <p>While we strive to fulfill all the requests we receive, the availability of the service depends on overall resource and personnel availability.</p>
 

--- a/tiaas-info.md
+++ b/tiaas-info.md
@@ -44,7 +44,7 @@ your workshop, then some of the <a href="https://usegalaxy.be/libraries/folders/
 your workshop, the trainees can fetch the example input data themselves as explained in the respective GTN guide. If you want to avoid potential temporary file transfer failures, you could provide the trainees with the data yourself beforehand as explained in the next point.</p>
   </li>
   <li>
-    <p>If you are using your own data, you can upload it to your account into a history. Later, you can <a href="https://usegalaxy.be/histories/sharing">make it accessible</a> to your trainees. Your trainees will then be able to <a href="https://usegalaxy.be/histories/import">import your history</a> and start working with your data.</p>
+    <p>If you are using your own data, you can upload it to your account into a history. Later, you can <a href="https://training.galaxyproject.org/training-material/faqs/galaxy/histories_sharing.html">make it accessible</a> to your trainees. Your trainees will then be able to <a href="https://usegalaxy.be/histories/import">import your history</a> and start working with your data.</p>
   </li>
 </ul>
 

--- a/tiaas-info.md
+++ b/tiaas-info.md
@@ -59,7 +59,7 @@ your workshop, the trainees can fetch the example input data themselves as expla
 <p>To keep running this free service for your trainees, <strong>we would like to ask your feedback and support</strong>. It would be great if you could:</p>
 
 <ul>
-  <li>Send us a (short) testimonial about your experience with the provided TIaaS to <a href="mailto:datacore.galaxy@vib.be">datacore.galaxy@vib.be</a>.</li>
+  <li>Send us a (short) testimonial about your experience with the provided TIaaS to datacore.galaxy(at)vib.be.</li>
   <li>If GTN material helped you in your training, please make sure to fill out the general <a href="https://galaxyproject.org/news/2020-01-training-feedback/"><strong>GTN Survey</strong></a>.</li>
   <li>If you used a GTN tutorial in your training, please fill in the feedback form that can be found at the end of every GTN tutorial.</li>
   <!-- <li>Post your training experience on social media tagging @galaxyproject or #galaxyproject.</li> -->

--- a/tiaas-info.md
+++ b/tiaas-info.md
@@ -48,7 +48,7 @@ your workshop, the trainees can fetch the example input data themselves as expla
   </li>
 </ul>
 
-<p>We recommend to use Galaxy’s default storage location during the training. This will help us in cleaning up unused data and offer Galaxy as a more sustainable service. To see which storage location is in use for your history, click on the <code class="language-plaintext highlighter-rouge">Preferred Storage Location</code> on the right panel (History panel).
+<p>We ask that unused and unnecessary data is cleaned up after the training, helping us offer Galaxy as a more sustainable service. To see which storage location is in use for your history, click on the <code class="language-plaintext highlighter-rouge">Preferred Storage Location</code> on the right panel (History panel).
 
 <p>You can learn more about managing storage options on the <a href="https://training.galaxyproject.org/training-material/faqs/galaxy/manage_your_galaxy_storage.html#tip-what-can-you-do-after-you-connected-a-storage">Galaxy Training Network page</a>.</p>
 

--- a/tiaas-info.md
+++ b/tiaas-info.md
@@ -19,25 +19,29 @@ You provide the training, we provide the <strong>infrastructure at no cost</stro
 
 <h2 id="how-tiaas-works">How TIaaS Works</h2>
 
-<p>We have several “pools” of virtual machines (VMs) attached to useGalaxy.be that run user jobs. For trainings that request TIaaS, we attach a new pool of VMs that is specially labelled for that training. When users join a training using a <strong>special URL</strong> we provide you, they are assigned to a <strong>special training group</strong>. Their jobs will then <strong>preferentially run on a training machine</strong>, and, in the event there is no more capacity, they will run on the main queue. If a spot on a training VM opens up first, they will run there rather than continuing to wait in the main queue. The jobs run by the rest of users on our server are instructed to avoid the training pools.</p>
+<p>To get started, fill in <a href="https://usegalaxy.be/tiaas/calendar/">the TIaaS request form</a>. After the request is approved, you will receive two links from us:</p>
+<ul>
+  <li>A link to the monitoring page for the trainer to track the progress of the trainees</li>
+  <li>A link for the trainees to register themselves for the training</li>
+</ul>
 
 <p>Some more general information about the TIaaS service:</p>
 
 <ul>
-  <li><a href="https://usegalaxy.be/tiaas/calendar/">A calendar</a> that shows when TIaaS trainings are booked.</li>
-  <li><a href="https://usegalaxy.be/tiaas/stats/">Some statistics</a> about the TIaaS events.</li>
+  <li>It has <a href="https://usegalaxy.be/tiaas/calendar/">a calendar</a> that shows when TIaaS trainings are booked.</li>
+  <li>You can find <a href="https://usegalaxy.be/tiaas/stats/">some statistics</a> about the TIaaS events.</li>
 </ul>
 
 <h3 id="before-the-training">Before the training</h3>
 
-<p>Before users can join a specific training, they need to be <strong>logged into the <a href="https://usegalaxy.be/">Belgian Galaxy server</a></strong>.</p>
+<p>Before users can join a specific training, they need to be <strong>logged into the <a href="https://usegalaxy.be/">Belgian Galaxy server</a></strong>. Only then can they register themselves through the link received from the trainer.</p>
 
 <p>To <strong>import data</strong>:</p>
 
 <ul>
-  <li>
-    <p>If you are using the <a href="https://training.galaxyproject.org/">Galaxy Training Network (GTN) material</a> for
-your workshop, then some of the <a href="https://usegalaxy.be/libraries/folders/F71dd6a15eadf6281">training data is already available on Galaxy BE</a>.</p>
+  <li><!-- <p>If you are using the <a href="https://training.galaxyproject.org/">Galaxy Training Network (GTN) material</a> for
+your workshop, then some of the <a href="https://usegalaxy.be/libraries/folders/F71dd6a15eadf6281">training data is already available on Galaxy BE</a>.</p> --><p>If you are using the <a href="https://training.galaxyproject.org/">Galaxy Training Network (GTN) material</a> for
+your workshop, the trainees can fetch the example input data themselves as explained in the respective GTN guide. If you want to avoid potential temporary file transfer failures, you could provide the trainees with the data yourself beforehand as explained in the next point.</p>
   </li>
   <li>
     <p>If you are using your own data, you can upload it to your account into a history. Later, you can <a href="https://usegalaxy.be/histories/sharing">make it accessible</a> to your trainees. Your trainees will then be able to <a href="https://usegalaxy.be/histories/import">import your history</a> and start working with your data.</p>
@@ -52,22 +56,22 @@ your workshop, then some of the <a href="https://usegalaxy.be/libraries/folders/
 
 <p>Once the training is over, the data will stay available for further use. However, we encourage you to <strong>clean up all the histories</strong> whenever this data will not be used anymore.</p>
 
-<p>To keep running this free service for your trainees, <strong>we need your feedback and support</strong>. It would be great if you could:</p>
+<p>To keep running this free service for your trainees, <strong>we would like to ask your feedback and support</strong>. It would be great if you could:</p>
 
 <ul>
-  <li>Write a (short) testimonial about your experience with the provided TIaaS.</li>
-  <li>Fill out the <a href="https://galaxyproject.org/news/2020-01-training-feedback/"><strong>GTN Survey</strong></a>.</li>
-  <li>Fill in the feedback form found at the end of every GTN tutorial.</li>
-  <li>Post your training experience on social media tagging @galaxyproject or #galaxyproject.</li>
+  <li>Send us a (short) testimonial about your experience with the provided TIaaS to <a href="mailto:datacore.galaxy@vib.be">datacore.galaxy@vib.be</a>.</li>
+  <li>Fill out the general <a href="https://galaxyproject.org/news/2020-01-training-feedback/"><strong>GTN Survey</strong></a>.</li>
+  <li>Fill in the feedback form that can be found at the end of every GTN tutorial.</li>
+  <!-- <li>Post your training experience on social media tagging @galaxyproject or #galaxyproject.</li> -->
 </ul>
 
 <h2 id="service-level-agreement">Service Level Agreement</h2>
 
-<p>We <em>cannot</em> promise any degree of uptime. We will do our best to have this service online and functioning during the entire time period, but there are cases where the service may experience interruptions that are outside of our control. We will keep you informed of any outages that may affect your training.</p>
+<p>We <em>cannot</em> promise any degree of uptime. We will do our best to have this service online and functioning during the entire time period of the training, but there are cases where the service may experience interruptions that are outside of our control. We will keep you informed of any outages that may affect your training.</p>
 
 <h2 id="eligibility">Eligibility</h2>
 
-<p>We have enough capacity to provide for trainings using our service. Anyone providing training on Galaxy is eligible to request the use of this service.</p>
+<p>Anyone wanting to provide training on Galaxy BE is eligible to request the use of this service.</p>
 
 <h2 id="application-process">Application Process</h2>
 
@@ -79,12 +83,11 @@ your workshop, then some of the <a href="https://usegalaxy.be/libraries/folders/
 
     <p>Please try to submit your application <strong>at least two weeks in advance of the training</strong>.</p>
   </li>
-  <li>With the information that you input in the form, we will:
+  <li>Get approval from the Galaxy BE admins, after which you will receive:
     <ul>
-      <li>Test the training material you plan on using,</li>
-      <li>Give you a URL your users will access to join the training,</li>
-      <li>give you a URL to the dashboard for you to see the queue status.</li>
+      <li>the URL your users will access to join the training,</li>
+      <li>the URL to the dashboard for you to see the progress of your trainees.</li>
     </ul>
   </li>
-  <li>Done! You are ready to run your training!</li>
+  <li>Done! You are ready to give your training!</li>
 </ol>

--- a/tiaas-info.md
+++ b/tiaas-info.md
@@ -13,7 +13,7 @@ You provide the training, we provide the <strong>infrastructure at no cost</stro
   <li>No Galaxy maintenance</li>
   <li>No Galaxy administration</li>
   <li>Free infrastructure</li>
-  <li>Make use of <a href="https://training.galaxyproject.org">Galaxy Training Materials</a>.</li>
+  <li>Make use of <a href="https://training.galaxyproject.org">Galaxy Training Materials</a></li>
   <li>See how your students are progressing on a dashboard</li>
 </ul>
 

--- a/tiaas-info.md
+++ b/tiaas-info.md
@@ -71,7 +71,7 @@ your workshop, the trainees can fetch the example input data themselves as expla
 
 <h2 id="Availability">Availability</h2>
 
-<p>Anyone wanting to provide training on Galaxy BE is eligible to request the use of this service.</p>
+<p>Anyone wanting to provide training on the Belgian Galaxy server is eligible to request the use of this service.</p>
 
 <h2 id="application-process">Application Process</h2>
 

--- a/tiaas-info.md
+++ b/tiaas-info.md
@@ -1,0 +1,90 @@
+---
+title: Training Infrastructure as a Service
+--- 
+
+
+<p>The <a href="https://usegalaxy.be">Belgian Galaxy Server</a> provides <strong>Training Infrastructure as a Service (TIaaS)</strong> for the Galaxy training community.
+You provide the training, we provide the <strong>infrastructure at no cost</strong>.</p>
+
+<h2 id="why-tiaas">Why TIaaS?</h2>
+
+<ul>
+  <!-- <li>Separate queue where only your training’s jobs will run.</li> -->
+  <li>No Galaxy maintenance.</li>
+  <li>No Galaxy administration.</li>
+  <li>Free infrastructure.</li>
+  <li>Make use of <a href="https://training.galaxyproject.org">Galaxy Training Materials</a>.</li>
+  <li>See how your students are progressing on a dashboard.</li>
+</ul>
+
+<h2 id="how-tiaas-works">How TIaaS Works</h2>
+
+<p>We have several “pools” of virtual machines (VMs) attached to useGalaxy.be that run user jobs. For trainings that request TIaaS, we attach a new pool of VMs that is specially labelled for that training. When users join a training using a <strong>special URL</strong> we provide you, they are assigned to a <strong>special training group</strong>. Their jobs will then <strong>preferentially run on a training machine</strong>, and, in the event there is no more capacity, they will run on the main queue. If a spot on a training VM opens up first, they will run there rather than continuing to wait in the main queue. The jobs run by the rest of users on our server are instructed to avoid the training pools.</p>
+
+<p>Some more general information about the TIaaS service:</p>
+
+<ul>
+  <li><a href="https://usegalaxy.be/tiaas/calendar/">A calendar</a> that shows when TIaaS trainings are booked.</li>
+  <li><a href="https://usegalaxy.be/tiaas/stats/">Some statistics</a> about the TIaaS events.</li>
+</ul>
+
+<h3 id="before-the-training">Before the training</h3>
+
+<p>Before users can join a specific training, they need to be <strong>logged into the <a href="https://usegalaxy.be/">Belgian Galaxy server</a></strong>.</p>
+
+<p>To <strong>import data</strong>:</p>
+
+<ul>
+  <li>
+    <p>If you are using the <a href="https://training.galaxyproject.org/">Galaxy Training Network (GTN) material</a> for
+your workshop, then some of the <a href="https://usegalaxy.be/libraries/folders/F71dd6a15eadf6281">training data is already available on Galaxy BE</a>.</p>
+  </li>
+  <li>
+    <p>If you are using your own data, you can upload it to your account into a history. Later, you can <a href="https://usegalaxy.be/histories/sharing">make it accessible</a> to your trainees. Your trainees will then be able to <a href="https://usegalaxy.be/histories/import">import your history</a> and start working with your data.</p>
+  </li>
+</ul>
+
+<p>We recommend to use Galaxy’s default storage location during the training. This will help us in cleaning up unused data and offer Galaxy as a more sustainable service. To see which storage location is in use for your history, click on the <code class="language-plaintext highlighter-rouge">Preferred Storage Location</code> on the right panel (History panel).
+
+<p>You can learn more about managing storage options on the <a href="https://training.galaxyproject.org/training-material/faqs/galaxy/manage_your_galaxy_storage.html#tip-what-can-you-do-after-you-connected-a-storage">Galaxy Training Network page</a>.</p>
+
+<h3 id="after-the-training">After the training</h3>
+
+<p>Once the training is over, the data will stay available for further use. However, we encourage you to <strong>clean up all the histories</strong> whenever this data will not be used anymore.</p>
+
+<p>To keep running this free service for your trainees, <strong>we need your feedback and support</strong>. It would be great if you could:</p>
+
+<ul>
+  <li>Write a (short) testimonial about your experience with the provided TIaaS.</li>
+  <li>Fill out the <a href="https://galaxyproject.org/news/2020-01-training-feedback/"><strong>GTN Survey</strong></a>.</li>
+  <li>Fill in the feedback form found at the end of every GTN tutorial.</li>
+  <li>Post your training experience on social media tagging @galaxyproject or #galaxyproject.</li>
+</ul>
+
+<h2 id="service-level-agreement">Service Level Agreement</h2>
+
+<p>We <em>cannot</em> promise any degree of uptime. We will do our best to have this service online and functioning during the entire time period, but there are cases where the service may experience interruptions that are outside of our control. We will keep you informed of any outages that may affect your training.</p>
+
+<h2 id="eligibility">Eligibility</h2>
+
+<p>We have enough capacity to provide for trainings using our service. Anyone providing training on Galaxy is eligible to request the use of this service.</p>
+
+<h2 id="application-process">Application Process</h2>
+
+<ol>
+  <li>
+    <p>Fill out the request form:</p>
+
+    <p><button type="button" class="btn btn-primary btn-lg" onclick="window.open('https://usegalaxy.be/tiaas/new/')">Request Training Infrastructure</button></p>
+
+    <p>Please try to submit your application <strong>at least two weeks in advance of the training</strong>.</p>
+  </li>
+  <li>With the information that you input in the form, we will:
+    <ul>
+      <li>Test the training material you plan on using,</li>
+      <li>Give you a URL your users will access to join the training,</li>
+      <li>give you a URL to the dashboard for you to see the queue status.</li>
+    </ul>
+  </li>
+  <li>Done! You are ready to run your training!</li>
+</ol>

--- a/tiaas-info.md
+++ b/tiaas-info.md
@@ -60,8 +60,8 @@ your workshop, the trainees can fetch the example input data themselves as expla
 
 <ul>
   <li>Send us a (short) testimonial about your experience with the provided TIaaS to <a href="mailto:datacore.galaxy@vib.be">datacore.galaxy@vib.be</a>.</li>
-  <li>Fill out the general <a href="https://galaxyproject.org/news/2020-01-training-feedback/"><strong>GTN Survey</strong></a>.</li>
-  <li>Fill in the feedback form that can be found at the end of every GTN tutorial.</li>
+  <li>If GTN material helped you in your training, please make sure to fill out the general <a href="https://galaxyproject.org/news/2020-01-training-feedback/"><strong>GTN Survey</strong></a>.</li>
+  <li>If you used a GTN tutorial in your training, please fill in the feedback form that can be found at the end of every GTN tutorial.</li>
   <!-- <li>Post your training experience on social media tagging @galaxyproject or #galaxyproject.</li> -->
 </ul>
 

--- a/tiaas-info.md
+++ b/tiaas-info.md
@@ -3,7 +3,7 @@ title: Training Infrastructure as a Service
 --- 
 
 
-<p>The <a href="https://usegalaxy.be">Belgian Galaxy Server</a> provides <strong>Training Infrastructure as a Service (TIaaS)</strong> for the Galaxy training community.
+<p>The <a href="https://usegalaxy.be">useGalaxy.be</a> server provides <strong>Training Infrastructure as a Service (TIaaS)</strong> for the Galaxy training community.
 You provide the training, we provide the <strong>infrastructure at no cost</strong>.</p>
 
 <h2 id="why-tiaas">Why TIaaS?</h2>
@@ -30,7 +30,7 @@ You provide the training, we provide the <strong>infrastructure at no cost</stro
 
 <h3 id="before-the-training">Before the training</h3>
 
-<p>Before users can join a specific training, they need to be <strong>logged into the <a href="https://usegalaxy.be/">Belgian Galaxy server</a></strong>.</p>
+<p>Before users can join a specific training, they need to be <strong>logged into the <a href="https://usegalaxy.be/">useGalaxy.be</a> server</strong>.</p>
 
 <p>To <strong>import data</strong>:</p>
 
@@ -56,18 +56,16 @@ your workshop, then some of the <a href="https://usegalaxy.be/libraries/folders/
 
 <ul>
   <li>Write a (short) testimonial about your experience with the provided TIaaS.</li>
-  <li>Fill out the <a href="https://galaxyproject.org/news/2020-01-training-feedback/"><strong>GTN Survey</strong></a>.</li>
-  <li>Fill in the feedback form found at the end of every GTN tutorial.</li>
-  <li>Post your training experience on social media tagging @galaxyproject or #galaxyproject.</li>
-</ul>
+  <li>If you made use of GTN material, fill in the feedback form found at the end of every GTN tutorial.</li>
+  </ul>
 
-<h2 id="service-level-agreement">Service Level Agreement</h2>
+<h2 id="disclaimer">Disclaimer</h2>
 
-<p>We <em>cannot</em> promise any degree of uptime. We will do our best to have this service online and functioning during the entire time period, but there are cases where the service may experience interruptions that are outside of our control. We will keep you informed of any outages that may affect your training.</p>
+<p>We <em>cannot</em> promise any degree of uptime. We will do our best to have this service online and functioning during the entire time period, but there are cases where the service may experience interruptions that are outside of our control.</p>
 
 <h2 id="eligibility">Eligibility</h2>
 
-<p>We have enough capacity to provide for trainings using our service. Anyone providing training on Galaxy is eligible to request the use of this service.</p>
+<p>While we strive to fulfill all the requests we receive, the availability of the service depends on overall resource and personnel availability.</p>
 
 <h2 id="application-process">Application Process</h2>
 
@@ -81,9 +79,9 @@ your workshop, then some of the <a href="https://usegalaxy.be/libraries/folders/
   </li>
   <li>With the information that you input in the form, we will:
     <ul>
-      <li>Test the training material you plan on using,</li>
-      <li>Give you a URL your users will access to join the training,</li>
-      <li>give you a URL to the dashboard for you to see the queue status.</li>
+      <li>Test the training material you plan on using</li>
+      <li>Give you a URL your users will access to join the training</li>
+      <li>Give you a URL to the dashboard for you to see the queue status</li>
     </ul>
   </li>
   <li>Done! You are ready to run your training!</li>


### PR DESCRIPTION
Closes #66.

Info page largely comes from EU: https://github.com/usegalaxy-eu/usegalaxy-eu.github.io/blob/e9c87eba900e14dbcf77a2f7850b1fcb7afb2f55/tiaas.html. Find the rendered version via their landing page at https://usegalaxy.eu via the 'Request TIaaS' button. 

As our setup currently differs, as in we will not configure TPV just yet to place the jobs of trainees in a seperate queue, that section still needs to be adapted.

Please review what else requires further adaptation, thanks!