### PR TITLE
Change notice to reflect resolved performance issue

### DIFF
--- a/_data/notices.yml
+++ b/_data/notices.yml
@@ -65,9 +65,9 @@
 #         Due to a training planned on 15.05.2023 traffic on usegalaxy.be can potentially be slow. Jobs submitted by users not part of the training are in a lower priority queue.
 
  - title: Degraded performance
-   class: warning  # one of [success, info, warning, danger]
+   class: success  # one of [success, info, warning, danger]
    messages:
      - message: |
-         The performance of useGalaxy.be is currently degraded. We apologize for any inconvenience caused.
+         The performance degradation has been resolved. 
 
  


### PR DESCRIPTION
Updated notice class from 'warning' to 'success' and modified message to indicate resolution.