### PR TITLE
Add a warning for job submission failure on the landing page

### DIFF
--- a/_data/notices.yml
+++ b/_data/notices.yml
@@ -4,6 +4,11 @@
 #       - message: |
 #           Here you can write some message for your users, [markdown](#asdf) is permitted.
 
+- title: Job submissions failed message 
+    class: warning  # one of [success, info, warning, danger]
+    messages:
+      - message: |
+        When submitting jobs, you may encounter a "Job submission failed" message even though your jobs get successfully submitted. You can simply close the message to resolve it. This is a known bug and we are working to resolve it. We apologize for the inconvenience.
 
 #- title: Scheduled maintenance — Friday 17 April, 14:00 - 18:00 CEST
 #  class: info  # one of [success, info, warning, danger]

--- a/_data/notices.yml
+++ b/_data/notices.yml
@@ -5,10 +5,10 @@
 #           Here you can write some message for your users, [markdown](#asdf) is permitted.
 
 - title: Job submissions failed message 
-    class: warning  # one of [success, info, warning, danger]
-    messages:
+  class: warning  # one of [success, info, warning, danger]
+  messages:
       - message: |
-        When submitting jobs, you may encounter a "Job submission failed" message even though your jobs get successfully submitted. You can simply close the message to resolve it. This is a known bug and we are working to resolve it. We apologize for the inconvenience.
+          When submitting jobs, you may encounter a "Job submission failed" message even though your jobs get successfully submitted. You can simply close the message to resolve it. This is a known bug and we are working to resolve it. We apologize for the inconvenience.
 
 #- title: Scheduled maintenance — Friday 17 April, 14:00 - 18:00 CEST
 #  class: info  # one of [success, info, warning, danger]

--- a/_data/notices.yml
+++ b/_data/notices.yml
@@ -4,11 +4,11 @@
 #       - message: |
 #           Here you can write some message for your users, [markdown](#asdf) is permitted.
 
-- title: Job submissions failed message 
+- title: Failed job submission pop-up message
   class: warning  # one of [success, info, warning, danger]
   messages:
       - message: |
-          When submitting jobs, you may encounter a "Job submission failed" message even though your jobs get successfully submitted. You can simply close the message to resolve it. This is a known bug and we are working to resolve it. We apologize for the inconvenience.
+          When submitting jobs, you may encounter a 'Job submission failed' message even though your jobs are successfully submitted. You can simply close the message to dismiss it. This is a known bug and we are working to resolve it. We apologize for the inconvenience.
 
 #- title: Scheduled maintenance — Friday 17 April, 14:00 - 18:00 CEST
 #  class: info  # one of [success, info, warning, danger]


### PR DESCRIPTION
As discussed after two users contacted us about it. See https://github.com/usegalaxy-be/infrastructure-playbook/issues/399 for more info. 

